### PR TITLE
Add git hooks via lefthook

### DIFF
--- a/lefthook.toml
+++ b/lefthook.toml
@@ -1,0 +1,6 @@
+[pre-commit]
+parallel = true
+
+[pre-commit.commands.biome]
+run = "npx biome check --apply --no-errors-on-unmatched --files-ignore-unknown=true {staged_files} && git update-index --again"
+glob = "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "@biomejs/biome": "^1.5.3",
     "@vitejs/plugin-react": "^4.2.1",
+    "lefthook": "^1.6.1",
     "nodemon": "^3.0.3",
     "vite": "^5.0.12",
     "vitest": "^1.2.2"


### PR DESCRIPTION
This will reliably enforce code style and code quality, even without vscode extensions installed to handle formatting.