### PR TITLE
Add basic support for editing data within C&P table

### DIFF
--- a/src/components/CostAndPricing/CostAndPricing.jsx
+++ b/src/components/CostAndPricing/CostAndPricing.jsx
@@ -1,10 +1,13 @@
+import { useState } from 'react';
 import { PricingTable } from './PricingTable';
 import { quote as sampleQuote } from './sample-data';
 
 export default function CostAndPricing() {
+  const [quote, setQuote] = useState(sampleQuote);
+
   return (
     <div>
-      <PricingTable quote={sampleQuote} />
+      <PricingTable quote={quote} />
     </div>
   );
 }

--- a/src/components/CostAndPricing/CostAndPricing.jsx
+++ b/src/components/CostAndPricing/CostAndPricing.jsx
@@ -7,7 +7,7 @@ export default function CostAndPricing() {
 
   return (
     <div>
-      <PricingTable quote={quote} />
+      <PricingTable quote={quote} setQuote={setQuote} />
     </div>
   );
 }

--- a/src/components/CostAndPricing/DataTable.jsx
+++ b/src/components/CostAndPricing/DataTable.jsx
@@ -15,7 +15,7 @@ import {
 /**
  * @param {object} props
  * @param {Product[]} props.data
- * @param {import('@tanstack/react-table').ColumnDef<Product>[]} props.columns
+ * @param {ProductColumnDef[]} props.columns
  */
 export function DataTable({ data, columns }) {
   const table = useReactTable({

--- a/src/components/CostAndPricing/PricingTable.jsx
+++ b/src/components/CostAndPricing/PricingTable.jsx
@@ -14,7 +14,15 @@ export function PricingTable({ quote, setQuote }) {
   // The @type JSDoc comments here are to get VSCode to understand
   // what these objects are.
 
-  /** @type {ProductColumn} */
+  /**
+   * Consistent columns that are always present.
+   *
+   * While I'd prefer having these defined in a completely separate file, they
+   * need to be defined as a part of this component so that the quote setter
+   * can get passed down to the cells.
+   *
+   * @type {ProductColumn}
+   */
   const consistentColumns = [
     { accessorKey: 'name', header: 'Name' },
     {

--- a/src/components/CostAndPricing/PricingTable.jsx
+++ b/src/components/CostAndPricing/PricingTable.jsx
@@ -8,8 +8,9 @@ import { staticColumns } from './columns';
 /**
  * @param {object} props
  * @param {Quote} props.quote
+ * @param {import('react').Dispatch<import('react').SetStateAction<Quote>>} props.setQuote
  */
-export function PricingTable({ quote }) {
+export function PricingTable({ quote, setQuote }) {
   // The @type JSDoc comments here are to get VSCode to understand
   // what these objects are.
 

--- a/src/components/CostAndPricing/PricingTable.jsx
+++ b/src/components/CostAndPricing/PricingTable.jsx
@@ -1,7 +1,7 @@
 // @ts-check
 
 import { DataTable } from './DataTable';
-import { DynamicCostCell } from './cells';
+import { ConsistentNumericCell, DynamicCostCell } from './cells';
 
 /** @typedef {import('@tanstack/react-table').ColumnDef<Product>[]} ProductColumn */
 
@@ -15,12 +15,56 @@ export function PricingTable({ quote, setQuote }) {
   // what these objects are.
 
   /** @type {ProductColumn} */
-  const staticColumns = [
+  const consistentColumns = [
     { accessorKey: 'name', header: 'Name' },
-    { accessorKey: 'quantity', header: 'Quantity' },
-    { accessorKey: 'selling_price', header: 'Selling Price' },
-    { accessorKey: 'total_selling_price', header: 'Total Selling Price' },
-    { accessorKey: 'estimated_hours', header: 'Estimated Hours' },
+    {
+      accessorKey: 'quantity',
+      header: 'Quantity',
+      cell: ({ getValue, row }) => (
+        <ConsistentNumericCell
+          getValue={getValue}
+          setQuote={setQuote}
+          productIndex={row.index}
+          accessorKey="quantity"
+        />
+      ),
+    },
+    {
+      accessorKey: 'selling_price',
+      header: 'Selling Price',
+      cell: ({ getValue, row }) => (
+        <ConsistentNumericCell
+          getValue={getValue}
+          setQuote={setQuote}
+          productIndex={row.index}
+          accessorKey="selling_price"
+        />
+      ),
+    },
+    {
+      accessorKey: 'total_selling_price',
+      header: 'Total Selling Price',
+      cell: ({ getValue, row }) => (
+        <ConsistentNumericCell
+          getValue={getValue}
+          setQuote={setQuote}
+          productIndex={row.index}
+          accessorKey="total_selling_price"
+        />
+      ),
+    },
+    {
+      accessorKey: 'estimated_hours',
+      header: 'Estimated Hours',
+      cell: ({ getValue, row }) => (
+        <ConsistentNumericCell
+          getValue={getValue}
+          setQuote={setQuote}
+          productIndex={row.index}
+          accessorKey="estimated_hours"
+        />
+      ),
+    },
   ];
 
   /**
@@ -55,7 +99,7 @@ export function PricingTable({ quote, setQuote }) {
    * All the columns the table uses.
    * This *should* get recalculated on rerenders.
    */
-  const columns = [...staticColumns, ...dynamicColumns];
+  const columns = [...consistentColumns, ...dynamicColumns];
 
   // The data table isn't a particularly generic component, but it's separated
   // from here so that it can be where the hook is used. That should ensure that

--- a/src/components/CostAndPricing/PricingTable.jsx
+++ b/src/components/CostAndPricing/PricingTable.jsx
@@ -3,8 +3,6 @@
 import { DataTable } from './DataTable';
 import { ConsistentNumericCell, DynamicCostCell } from './cells';
 
-/** @typedef {import('@tanstack/react-table').ColumnDef<Product>[]} ProductColumn */
-
 /**
  * @param {object} props
  * @param {Quote} props.quote
@@ -21,7 +19,7 @@ export function PricingTable({ quote, setQuote }) {
    * need to be defined as a part of this component so that the quote setter
    * can get passed down to the cells.
    *
-   * @type {ProductColumn}
+   * @type {ProductColumnDef[]}
    */
   const consistentColumns = [
     { accessorKey: 'name', header: 'Name' },
@@ -86,7 +84,7 @@ export function PricingTable({ quote, setQuote }) {
    * {@link https://react.dev/learn/you-might-not-need-an-effect You Might Not Need an Effect}
    * page suggests that this should be avoidable, and that this can be done
    * during rendering.
-   * @type {ProductColumn}
+   * @type {ProductColumnDef[]}
    */
   const dynamicColumns = quote.products[0].costs.map((cost, index) => ({
     accessorFn: (row) => row.costs[index].value,

--- a/src/components/CostAndPricing/PricingTable.jsx
+++ b/src/components/CostAndPricing/PricingTable.jsx
@@ -6,7 +6,7 @@ import { ConsistentNumericCell, DynamicCostCell } from './cells';
 /**
  * @param {object} props
  * @param {Quote} props.quote
- * @param {import('react').Dispatch<import('react').SetStateAction<Quote>>} props.setQuote
+ * @param {React.Dispatch<React.SetStateAction<Quote>>} props.setQuote
  */
 export function PricingTable({ quote, setQuote }) {
   // The @type JSDoc comments here are to get VSCode to understand

--- a/src/components/CostAndPricing/PricingTable.jsx
+++ b/src/components/CostAndPricing/PricingTable.jsx
@@ -2,7 +2,6 @@
 
 import { DataTable } from './DataTable';
 import { DynamicCostCell } from './cells';
-import { staticColumns } from './columns';
 
 /** @typedef {import('@tanstack/react-table').ColumnDef<Product>[]} ProductColumn */
 
@@ -14,6 +13,15 @@ import { staticColumns } from './columns';
 export function PricingTable({ quote, setQuote }) {
   // The @type JSDoc comments here are to get VSCode to understand
   // what these objects are.
+
+  /** @type {ProductColumn} */
+  const staticColumns = [
+    { accessorKey: 'name', header: 'Name' },
+    { accessorKey: 'quantity', header: 'Quantity' },
+    { accessorKey: 'selling_price', header: 'Selling Price' },
+    { accessorKey: 'total_selling_price', header: 'Total Selling Price' },
+    { accessorKey: 'estimated_hours', header: 'Estimated Hours' },
+  ];
 
   /**
    * The dynamic columns that the table uses. They're generated from the frist

--- a/src/components/CostAndPricing/PricingTable.jsx
+++ b/src/components/CostAndPricing/PricingTable.jsx
@@ -1,6 +1,7 @@
 // @ts-check
 
 import { DataTable } from './DataTable';
+import { DynamicCostCell } from './cells';
 import { staticColumns } from './columns';
 
 /** @typedef {import('@tanstack/react-table').ColumnDef<Product>[]} ProductColumn */
@@ -30,6 +31,16 @@ export function PricingTable({ quote, setQuote }) {
   const dynamicColumns = quote.products[0].costs.map((cost, index) => ({
     accessorFn: (row) => row.costs[index].value,
     header: cost.name,
+    cell: ({ getValue, row }) => {
+      return (
+        <DynamicCostCell
+          getValue={getValue}
+          setQuote={setQuote}
+          productIndex={row.index}
+          costIndex={index}
+        />
+      );
+    },
   }));
 
   /**

--- a/src/components/CostAndPricing/cells.jsx
+++ b/src/components/CostAndPricing/cells.jsx
@@ -8,10 +8,10 @@ import { useEffect, useState } from 'react';
  * @template {(string|number)} T
  * @param {Object} props
  * @param {import("@tanstack/react-table").Getter<T>} props.getValue the getValue function from tanstack tables
- * @param {import("react").Dispatch<import("react").SetStateAction<Quote>>} props.setQuote the setter for the entire quote
+ * @param {React.Dispatch<React.SetStateAction<Quote>>} props.setQuote the setter for the entire quote
  * @param {number} props.productIndex the index of the product in the quote.
  * @param {number} props.costIndex the index of the cost in the product.
- * @returns {import('react').ReactNode}
+ * @returns {JSX.Element}
  */
 export function DynamicCostCell({
   getValue,
@@ -57,10 +57,10 @@ export function DynamicCostCell({
  * @template {(string|number)} T
  * @param {Object} props
  * @param {import("@tanstack/react-table").Getter<T>} props.getValue the getValue function from tanstack tables
- * @param {import("react").Dispatch<import("react").SetStateAction<Quote>>} props.setQuote the setter for the entire quote
+ * @param {React.Dispatch<React.SetStateAction<Quote>>} props.setQuote the setter for the entire quote
  * @param {number} props.productIndex the index of the product in the quote.
  * @param {("quantity"|"selling_price"|"total_selling_price"|"estimated_hours")} props.accessorKey the key for the property in the product being modified.
- * @returns {import('react').ReactNode}
+ * @returns {JSX.Element}
  */
 export function ConsistentNumericCell({
   getValue,

--- a/src/components/CostAndPricing/cells.jsx
+++ b/src/components/CostAndPricing/cells.jsx
@@ -1,0 +1,47 @@
+// @ts-check
+
+import { produce } from 'immer';
+import { useEffect, useState } from 'react';
+
+/**
+ * A component that renders editable cells with dynamic costs
+ * @template {(string|number)} T
+ * @param {Object} props
+ * @param {import("@tanstack/react-table").Getter<T>} props.getValue
+ * @param {import("react").Dispatch<import("react").SetStateAction<Quote>>} props.setQuote
+ * @param {number} props.productIndex
+ * @param {number} props.costIndex
+ * @returns {JSX.Element}
+ */
+export function DynamicCostCell({
+  getValue,
+  setQuote,
+  productIndex,
+  costIndex,
+}) {
+  /** @type {T} */
+  const initialValue = getValue();
+  const [value, setValue] = useState(initialValue);
+
+  // onBlur is called when the input loses focus.
+  const onBlur = () => {
+    setQuote(
+      produce((/** @type {Quote} */ draft) => {
+        draft.products[productIndex].costs[costIndex].value = Number(value);
+      }),
+    );
+  };
+
+  useEffect(() => {
+    setValue(initialValue);
+  }, [initialValue]);
+
+  return (
+    <input
+      value={value}
+      // @ts-ignore
+      onChange={(e) => setValue(e.target.value)}
+      onBlur={onBlur}
+    />
+  );
+}

--- a/src/components/CostAndPricing/cells.jsx
+++ b/src/components/CostAndPricing/cells.jsx
@@ -45,3 +45,46 @@ export function DynamicCostCell({
     />
   );
 }
+
+/**
+ * A component for the quantity, selling price, total selling price, and estimated hours cells.
+ * @template {(string|number)} T
+ * @param {Object} props
+ * @param {import("@tanstack/react-table").Getter<T>} props.getValue
+ * @param {import("react").Dispatch<import("react").SetStateAction<Quote>>} props.setQuote
+ * @param {number} props.productIndex
+ * @param {("quantity"|"selling_price"|"total_selling_price"|"estimated_hours")} props.accessorKey
+ * @returns {JSX.Element}
+ */
+export function ConsistentNumericCell({
+  getValue,
+  setQuote,
+  productIndex,
+  accessorKey,
+}) {
+  /** @type {T} */
+  const initialValue = getValue();
+  const [value, setValue] = useState(initialValue);
+
+  // onBlur is called when the input loses focus.
+  const onBlur = () => {
+    setQuote(
+      produce((/** @type {Quote} */ draft) => {
+        draft.products[productIndex][accessorKey] = Number(value);
+      }),
+    );
+  };
+
+  useEffect(() => {
+    setValue(initialValue);
+  }, [initialValue]);
+
+  return (
+    <input
+      value={value}
+      // @ts-ignore
+      onChange={(e) => setValue(e.target.value)}
+      onBlur={onBlur}
+    />
+  );
+}

--- a/src/components/CostAndPricing/cells.jsx
+++ b/src/components/CostAndPricing/cells.jsx
@@ -7,11 +7,11 @@ import { useEffect, useState } from 'react';
  * A component that renders editable cells with dynamic costs
  * @template {(string|number)} T
  * @param {Object} props
- * @param {import("@tanstack/react-table").Getter<T>} props.getValue
- * @param {import("react").Dispatch<import("react").SetStateAction<Quote>>} props.setQuote
- * @param {number} props.productIndex
- * @param {number} props.costIndex
- * @returns {JSX.Element}
+ * @param {import("@tanstack/react-table").Getter<T>} props.getValue the getValue function from tanstack tables
+ * @param {import("react").Dispatch<import("react").SetStateAction<Quote>>} props.setQuote the setter for the entire quote
+ * @param {number} props.productIndex the index of the product in the quote.
+ * @param {number} props.costIndex the index of the cost in the product.
+ * @returns {import('react').ReactNode}
  */
 export function DynamicCostCell({
   getValue,
@@ -23,7 +23,12 @@ export function DynamicCostCell({
   const initialValue = getValue();
   const [value, setValue] = useState(initialValue);
 
-  // onBlur is called when the input loses focus.
+  /**
+   * onBlur is called when the input loses focus.
+   * It updates the quote with the new value, using an immer produce function
+   * to simplify state updates.
+   * @see {@link https://immerjs.github.io/immer/example-setstate#usestate--immer useState + Immer}
+   */
   const onBlur = () => {
     setQuote(
       produce((/** @type {Quote} */ draft) => {
@@ -32,6 +37,7 @@ export function DynamicCostCell({
     );
   };
 
+  // This useEffect comes from tanstack table examples. I'm not 100% sure it's actually needed.
   useEffect(() => {
     setValue(initialValue);
   }, [initialValue]);
@@ -50,11 +56,11 @@ export function DynamicCostCell({
  * A component for the quantity, selling price, total selling price, and estimated hours cells.
  * @template {(string|number)} T
  * @param {Object} props
- * @param {import("@tanstack/react-table").Getter<T>} props.getValue
- * @param {import("react").Dispatch<import("react").SetStateAction<Quote>>} props.setQuote
- * @param {number} props.productIndex
- * @param {("quantity"|"selling_price"|"total_selling_price"|"estimated_hours")} props.accessorKey
- * @returns {JSX.Element}
+ * @param {import("@tanstack/react-table").Getter<T>} props.getValue the getValue function from tanstack tables
+ * @param {import("react").Dispatch<import("react").SetStateAction<Quote>>} props.setQuote the setter for the entire quote
+ * @param {number} props.productIndex the index of the product in the quote.
+ * @param {("quantity"|"selling_price"|"total_selling_price"|"estimated_hours")} props.accessorKey the key for the property in the product being modified.
+ * @returns {import('react').ReactNode}
  */
 export function ConsistentNumericCell({
   getValue,
@@ -66,8 +72,12 @@ export function ConsistentNumericCell({
   const initialValue = getValue();
   const [value, setValue] = useState(initialValue);
 
-  // onBlur is called when the input loses focus.
-  const onBlur = () => {
+  /**
+   * onBlur is called when the input loses focus.
+   * It updates the quote with the new value, using an immer produce function
+   * to simplify state updates.
+   * @see {@link https://immerjs.github.io/immer/example-setstate#usestate--immer useState + Immer}
+   */ const onBlur = () => {
     setQuote(
       produce((/** @type {Quote} */ draft) => {
         draft.products[productIndex][accessorKey] = Number(value);

--- a/src/components/CostAndPricing/data-types.d.ts
+++ b/src/components/CostAndPricing/data-types.d.ts
@@ -18,3 +18,5 @@ interface Quote {
   name: string;
   products: Product[];
 }
+
+type ProductColumnDef = import('@tanstack/react-table').ColumnDef<Product>;


### PR DESCRIPTION
Not necessarily 100% finished.

Uses immer to manipulate the quote with the onBlur event, which runs when the input loses focus. This might be worth changing to onChange, or making it an effect of modifying the value.

Cost names currently can't be modified, since that'll need to be set in the header of the cell. I will make that another PR.

Also, nothing here uses mui inputs yet. I will do that after the table has the correct layout.