### PR TITLE
Fix admin page CSS breaking other pages

### DIFF
--- a/src/components/AdminPage/AdminPage.jsx
+++ b/src/components/AdminPage/AdminPage.jsx
@@ -1,8 +1,7 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import ApprovedAdminTable from '../ApprovedAdminTable/ApprovedAdminTable';
 import PendingAdminTable from '../PendingAdminTable/PendingAdminTable';
-import './adminPage.css';
 
 function AdminPage() {
   const dispatch = useDispatch();


### PR DESCRIPTION
I just removed the import for the css file, but I left the css file there for reference

This should fix any bugs on other pages caused by the CSS