### PR TITLE
Import non-minified version of react-router-dom

### DIFF
--- a/src/components/AppBarHeader/AppBarHeader.jsx
+++ b/src/components/AppBarHeader/AppBarHeader.jsx
@@ -6,7 +6,7 @@ import MenuItem from '@mui/material/MenuItem';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import { useState } from 'react';
-import { useHistory } from 'react-router-dom/cjs/react-router-dom.min';
+import { useHistory } from 'react-router-dom';
 
 const drawerWidth = 240;
 


### PR DESCRIPTION
Thanks VSCode for downloading the wrong version of react-router-dom's types