### PR TITLE
Ensure account page CSS can't apply on other pages

### DIFF
--- a/src/components/MyAccountPage/MyAccountPage.css
+++ b/src/components/MyAccountPage/MyAccountPage.css
@@ -20,7 +20,7 @@
 }
 
 .accountPageFormArea section,
-p {
+.accountPageFormArea p {
   font-size: 28px;
   align-items: center;
   display: flex;


### PR DESCRIPTION
Changed the `p` selector to `.accountPageFormArea p` to avoid bugs