### PR TITLE
Make sessions persistent

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -17,6 +17,7 @@ DROP TABLE IF EXISTS "product";
 DROP TABLE IF EXISTS "quote";
 DROP TABLE IF EXISTS "user";
 DROP TABLE IF EXISTS "company";
+DROP TABLE IF EXISTS "session";
 
 
 CREATE TABLE "company" (
@@ -129,3 +130,17 @@ FOR EACH ROW
 EXECUTE PROCEDURE set_updated_at_to_now();
 
 SET TIMEZONE = 'America/Chicago'; 
+
+-- This is from node_modules/connect-pg-simple/table.sql
+CREATE TABLE "session" (
+	"sid" varchar NOT NULL COLLATE "default",
+	"sess" json NOT NULL,
+	"expire" timestamp(6) NOT NULL
+) WITH (OIDS = FALSE);
+
+ALTER TABLE
+	"session"
+ADD
+	CONSTRAINT "session_pkey" PRIMARY KEY ("sid") NOT DEFERRABLE INITIALLY IMMEDIATE;
+
+CREATE INDEX "IDX_session_expire" ON "session" ("expire");

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "express": "^4.18.2",
     "express-session": "^1.18.0",
     "immer": "^10.0.3",
-    "memorystore": "^1.6.7",
     "passport": "^0.7.0",
     "passport-local": "^1.0.0",
     "pg": "^8.11.3",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@tanstack/react-table": "^8.11.7",
     "axios": "^1.6.7",
     "bcryptjs": "^2.4.3",
+    "connect-pg-simple": "^9.0.1",
     "dotenv": "^16.4.1",
     "express": "^4.18.2",
     "express-session": "^1.18.0",

--- a/server/middleware/session.cjs
+++ b/server/middleware/session.cjs
@@ -1,10 +1,11 @@
 // @ts-check
 
 const expressSession = require('express-session');
-const createMemoryStore = require('memorystore');
+const createPGStore = require('connect-pg-simple');
 const { badSecret, exampleBadSecret } = require('../constants/warnings');
+const pool = require('../modules/pool');
 
-const MemoryStore = createMemoryStore(expressSession);
+const PGStore = createPGStore(expressSession);
 
 function serverSessionSecret() {
   if (
@@ -20,9 +21,9 @@ function serverSessionSecret() {
 }
 
 const middleware = expressSession({
-  cookie: { maxAge: 86400000 },
-  store: new MemoryStore({
-    checkPeriod: 86400000, // prune expired entries every 24h
+  cookie: { maxAge: 30 * 24 * 60 * 60 * 1000 }, // 30 days
+  store: new PGStore({
+    pool,
   }),
   resave: false, // don't save session if unmodified
   saveUninitialized: false, // don't create session until something stored


### PR DESCRIPTION
This PR changes the session store from memorystore to connect-pg-simple, and makes it so sessions persist for 30 days.