### PR TITLE
Disable useLiteralKeys biome rule

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -29,6 +29,9 @@
     "enabled": true,
     "rules": {
       "recommended": true,
+      "complexity": {
+        "useLiteralKeys": "off"
+      },
       "correctness": {
         "useHookAtTopLevel": "warn"
       },


### PR DESCRIPTION
It disagrees with typescript's rules in certain contexts