### PR TITLE
Fix critical bugs in pricing tool

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -26,7 +26,7 @@ CREATE TABLE "company" (
 	"is_removed" BOOLEAN DEFAULT FALSE,
 	"inserted_at" TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
 	"updated_at" TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-	"updated_by" INT
+	"updated_by" INT DEFAULT NULL -- FK constraint can't be set yet
 );
 
 CREATE TABLE "user" (
@@ -42,8 +42,13 @@ CREATE TABLE "user" (
 	"last_login" TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
 	"inserted_at" TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
 	"updated_at" TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-	"updated_by" INT
+	"updated_by" INT REFERENCES "user"("id") ON DELETE SET NULL DEFAULT NULL
 );
+
+ALTER TABLE company
+ADD CONSTRAINT company_updated_by_fkey
+FOREIGN KEY (updated_by)
+REFERENCES "user"(id) ON DELETE SET NULL;
 
 CREATE TABLE "pending_user_company" (
 	"id" SERIAL PRIMARY KEY,
@@ -51,7 +56,7 @@ CREATE TABLE "pending_user_company" (
 	"name" VARCHAR(100) DEFAULT NULL,
 	"inserted_at" TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
 	"updated_at" TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-	"updated_by" INT
+	"updated_by" INT REFERENCES "user"("id") ON DELETE SET NULL DEFAULT NULL
 );
 
 CREATE TABLE "quote" (
@@ -63,7 +68,7 @@ CREATE TABLE "quote" (
 	"is_removed" BOOLEAN DEFAULT FALSE,
 	"inserted_at" TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
 	"updated_at" TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-	"updated_by" INT 
+	"updated_by" INT REFERENCES "user"("id") ON DELETE SET NULL DEFAULT NULL 
 );
 
 CREATE TABLE "product" (
@@ -77,7 +82,7 @@ CREATE TABLE "product" (
 	"is_removed" BOOLEAN DEFAULT FALSE,
 	"inserted_at" TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
 	"updated_at" TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-	"updated_by" INT 
+	"updated_by" INT REFERENCES "user"("id") ON DELETE SET NULL DEFAULT NULL 
 );
 
 CREATE TABLE "cost" (
@@ -88,7 +93,7 @@ CREATE TABLE "cost" (
 	"is_removed" BOOLEAN DEFAULT FALSE,
 	"inserted_at" TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
 	"updated_at" TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-	"updated_by" INT,
+	"updated_by" INT REFERENCES "user"("id") ON DELETE SET NULL DEFAULT NULL,
 	UNIQUE (product_id, name) -- prevents broken quotes from being inserted
 );
 

--- a/database.sql
+++ b/database.sql
@@ -88,7 +88,8 @@ CREATE TABLE "cost" (
 	"is_removed" BOOLEAN DEFAULT FALSE,
 	"inserted_at" TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
 	"updated_at" TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-	"updated_by" INT 
+	"updated_by" INT,
+	UNIQUE (product_id, name) -- prevents broken quotes from being inserted
 );
 
 CREATE FUNCTION set_updated_at_to_now()

--- a/server/routes/quote.router.js
+++ b/server/routes/quote.router.js
@@ -62,6 +62,8 @@ router.get('/:id', (req, res) => {
 			product_id,
 			json_agg(
 			json_build_object(
+        'id',
+          c.id,
 				'name',
 					c.name,
 				'value',

--- a/src/components/CostAndPricing/PricingTab/PricingTable.jsx
+++ b/src/components/CostAndPricing/PricingTab/PricingTable.jsx
@@ -55,14 +55,13 @@ export function PricingTable({ quote, setQuote }) {
    * the `.filter` call removes duplicates names.
    * @type {import('./data-types').ProductColumnDef[]}
    */
-  const dynamicColumns = (quote.products ?? [])
-    .flatMap((product) => (product.costs ?? []).map((cost) => cost.name))
+  const dynamicColumns = quote.products
+    .flatMap((product) => product.costs.map((cost) => cost.name))
     .filter(unique)
     .map((name) => ({
       // The ID is how we can use getValue for calculations.
       id: `dynamic-cost-${name}`,
-      accessorFn: (row) =>
-        (row.costs ?? []).find((c) => c.name === name)?.value ?? 0,
+      accessorFn: (row) => row.costs.find((c) => c.name === name)?.value ?? 0,
       header: DynamicCostHeader,
       cell: DynamicCostCell,
       aggregationFn: 'sum',
@@ -89,7 +88,7 @@ export function PricingTable({ quote, setQuote }) {
   ];
 
   const table = useReactTable({
-    data: quote.products ?? [],
+    data: quote.products,
     columns,
     getCoreRowModel: getCoreRowModel(),
     // The meta option is how we can pass the setQuote function to the cells.

--- a/src/components/CostAndPricing/PricingTab/actions.jsx
+++ b/src/components/CostAndPricing/PricingTab/actions.jsx
@@ -41,11 +41,10 @@ function SaveQuote({ quote, setQuote }) {
   const dispatch = useDispatch();
 
   const [dialogOpen, setDialogOpen] = useState(false);
-  const [name, setName] = useState(quote.name ?? '');
   const [snackbarOpen, setSnackbarOpen] = useState(false);
 
   const saveQuote = () => {
-    dispatch({ type: 'SAGA/SAVE_QUOTE', payload: { ...quote, name } });
+    dispatch({ type: 'SAGA/SAVE_QUOTE', payload: quote });
   };
 
   /**
@@ -53,18 +52,23 @@ function SaveQuote({ quote, setQuote }) {
    */
   const handleSubmit = (e) => {
     e.preventDefault();
-    setQuote(
-      produce((/** @type {import('./data-types').Quote} */ draft) => {
-        draft.name = name;
-      }),
-    );
     saveQuote();
     setDialogOpen(false);
     setSnackbarOpen(true);
   };
   const closeDialog = () => {
     setDialogOpen(false);
-    setName(quote.name ?? '');
+  };
+
+  /**
+   * @type {import('react').ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement>}
+   */
+  const setQuoteName = (e) => {
+    setQuote(
+      produce((/** @type {import('./data-types').Quote} */ draft) => {
+        draft.name = e.target.value;
+      }),
+    );
   };
 
   return (
@@ -98,8 +102,8 @@ function SaveQuote({ quote, setQuote }) {
             id="quoteName"
             name="quoteName"
             label="Quote Name"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
+            value={quote.name}
+            onChange={setQuoteName}
           />
         </DialogContent>
         <DialogActions>

--- a/src/components/CostAndPricing/PricingTab/actions.jsx
+++ b/src/components/CostAndPricing/PricingTab/actions.jsx
@@ -75,7 +75,7 @@ function SaveQuote({ quote, setQuote }) {
         startIcon={<Save />}
         onClick={() => setDialogOpen(true)}
       >
-        Save
+        Save as new quote
       </Button>
       <Dialog
         open={dialogOpen}

--- a/src/components/CostAndPricing/PricingTab/cells.jsx
+++ b/src/components/CostAndPricing/PricingTab/cells.jsx
@@ -303,7 +303,7 @@ export function AddCostHeader({ table }) {
     table.options.meta?.setQuote(
       produce((/** @type {import('./data-types').Quote} */ draft) => {
         if (draft.products === undefined || draft.products === null) {
-          throw new Error('Malformed quote: products is undefined');
+          draft.products = [];
         }
         for (const product of draft.products) {
           if (product.costs === undefined) {

--- a/src/components/CostAndPricing/PricingTab/cells.jsx
+++ b/src/components/CostAndPricing/PricingTab/cells.jsx
@@ -392,16 +392,14 @@ export function AddProductCell({ table }) {
   const addProduct = () => {
     table.options.meta?.setQuote(
       produce((/** @type {import('./data-types').Quote} */ draft) => {
-        // This is the only place where we should repair the products array.
-        // In any other place, the products array would need to be correct for
-        // the component to appear in the first place.
+        // This code is now preventing what should be an impossible crash.
         if (draft.products === undefined || draft.products === null) {
           draft.products = [];
         }
 
         // This is probably the safest way to get a unique list of cost names.
         const costNames = draft.products
-          .flatMap((p) => (p.costs ?? []).map((c) => c.name))
+          .flatMap((product) => product.costs.map((c) => c.name))
           .filter(unique);
 
         // This *should* also work, but it might not order things correctly,

--- a/src/components/CostAndPricing/PricingTab/data-repair.js
+++ b/src/components/CostAndPricing/PricingTab/data-repair.js
@@ -1,0 +1,53 @@
+// @ts-check
+
+import { emptyQuote } from './sample-data';
+
+/**
+ * Repairs potentially broken quotes recieved from the server.
+ * @param {import("./data-types").DamaagedQuote} quote
+ * @returns {import("./data-types").Quote}
+ */
+export function repairQuote(quote) {
+  // If the quote is undefined or null, return the default quote
+  if (quote === undefined || quote === null) {
+    return emptyQuote;
+  }
+  return {
+    id: quote.id ?? undefined,
+    name: quote.name ?? '',
+    manual_contribution_percent: quote.manual_contribution_percent ?? 0,
+    manual_total_selling_price: quote.manual_total_selling_price ?? undefined,
+    // The inserted_at and created_by fields are dropped hre
+    products: (quote.products ?? []).map(repairProduct),
+  };
+}
+
+/**
+ * Repairs a broken product from a quote
+ * @param {import('./data-types').DamagedProduct} product
+ * @returns {import('./data-types').Product}
+ */
+function repairProduct(product) {
+  return {
+    id: product.id ?? undefined,
+    name: product.name ?? 'Unnamed Product',
+    quantity: product.quantity ?? 0,
+    selling_price_per_unit: product.selling_price_per_unit ?? 0,
+    total_selling_price: product.total_selling_price ?? undefined,
+    estimated_hours: product.estimated_hours ?? 0,
+    costs: (product.costs ?? []).map(repairCost),
+  };
+}
+
+/**
+ * Repairs a broken cost from a product
+ * @param {import('./data-types').DamagedCost} cost
+ * @returns {import('./data-types').Cost}
+ */
+function repairCost(cost) {
+  return {
+    id: cost.id ?? undefined,
+    name: cost.name ?? 'Unnamed Cost',
+    value: cost.value ?? 0,
+  };
+}

--- a/src/components/CostAndPricing/PricingTab/data-types.d.ts
+++ b/src/components/CostAndPricing/PricingTab/data-types.d.ts
@@ -12,7 +12,7 @@ export interface Cost {
   value: number;
 }
 
-type DamagedCost = DamagedStruct<Cost>;
+export type DamagedCost = DamagedStruct<Cost>;
 
 export interface Product {
   id?: number;
@@ -24,7 +24,7 @@ export interface Product {
   costs?: Cost[];
 }
 
-type DamagedProduct = DamagedStruct<
+export type DamagedProduct = DamagedStruct<
   Omit<Product, 'costs'> & {
     costs?: DamagedCost[];
   }

--- a/src/components/CostAndPricing/PricingTab/data-types.d.ts
+++ b/src/components/CostAndPricing/PricingTab/data-types.d.ts
@@ -21,7 +21,7 @@ export interface Product {
   selling_price_per_unit: number;
   total_selling_price?: number;
   estimated_hours: number;
-  costs?: Cost[];
+  costs: Cost[];
 }
 
 export type DamagedProduct = DamagedStruct<
@@ -37,7 +37,7 @@ export interface Quote {
   manual_total_selling_price?: number;
   inserted_at?: string;
   created_by?: string;
-  products?: Product[];
+  products: Product[];
 }
 
 // This type represents the absolute maximum degree of bad data the client

--- a/src/components/CostAndPricing/PricingTab/data-types.d.ts
+++ b/src/components/CostAndPricing/PricingTab/data-types.d.ts
@@ -42,10 +42,13 @@ export interface Quote {
 
 // This type represents the absolute maximum degree of bad data the client
 // can accept from the server. Every property can be null or undefined.
-export type DamaagedQuote = DamagedStruct<
-  Omit<Quote, 'products'> & {
-    products?: DamagedProduct[];
-  }
->;
+export type DamaagedQuote =
+  | DamagedStruct<
+      Omit<Quote, 'products'> & {
+        products?: DamagedProduct[];
+      }
+    >
+  | undefined
+  | null;
 
 export type ProductColumnDef = ColumnDef<Product>;

--- a/src/components/CostAndPricing/PricingTab/data-types.d.ts
+++ b/src/components/CostAndPricing/PricingTab/data-types.d.ts
@@ -2,11 +2,17 @@
 
 import type { ColumnDef } from '@tanstack/react-table';
 
+type DamagedStruct<T> = {
+  [P in keyof T]?: T[P] | null;
+};
+
 export interface Cost {
   id?: number;
   name: string;
   value: number;
 }
+
+type DamagedCost = DamagedStruct<Cost>;
 
 export interface Product {
   id?: number;
@@ -18,6 +24,12 @@ export interface Product {
   costs?: Cost[];
 }
 
+type DamagedProduct = DamagedStruct<
+  Omit<Product, 'costs'> & {
+    costs?: DamagedCost[];
+  }
+>;
+
 export interface Quote {
   id?: number;
   name: string;
@@ -27,5 +39,13 @@ export interface Quote {
   created_by?: string;
   products?: Product[];
 }
+
+// This type represents the absolute maximum degree of bad data the client
+// can accept from the server. Every property can be null or undefined.
+export type DamaagedQuote = DamagedStruct<
+  Omit<Quote, 'products'> & {
+    products?: DamagedProduct[];
+  }
+>;
 
 export type ProductColumnDef = ColumnDef<Product>;

--- a/src/components/CostAndPricing/PricingTab/index.jsx
+++ b/src/components/CostAndPricing/PricingTab/index.jsx
@@ -2,10 +2,11 @@
 import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import { PricingTable } from './PricingTable';
+import { repairQuote } from './data-repair';
 
 export function PricingTab() {
   /** @type {import('./data-types').Quote} */
-  const currentQuote = useSelector((state) => state.quote.current);
+  const currentQuote = useSelector((state) => repairQuote(state.quote.current));
   const [quote, setQuote] = useState(currentQuote);
 
   return <PricingTable quote={quote} setQuote={setQuote} />;


### PR DESCRIPTION
- Fixes #133
- Fixes #134
- Fixes #138
- Changes save button text in pricing tool
- Updated database to prevent duplicate cost names
- Updated database to add foreign key constraints for `updated_by` columns

# Updating quotes broke (#133)

This seems to have been just caused by cost IDs not being sent in the quote history, which causes the quote to have increasigly nonsensical data in it.

# Pricing table crashes (#134)

The server can output slightly malformed data, so this mostly involved adding an atually robust check that quotes and their components are not malformed when being added to the pricing tool. It should actually be safe to remove some null-safety checks because of this, since the quote should *never* have any missing properties now.

# Quote name not reset when creating new quote (#138)

The input had some internal state tracking the quote name, which ends up detached from the overall quote. Removing this fixes the issue.