### PR TITLE
Don't pipe server output into vite during npm start

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint:biome": "biome check .",
     "lint:prettier": "prettier --check .",
     "server": "nodemon --watch server server/server.js",
-    "start": "node server/server.js | vite",
+    "start": "node server/server.js",
     "test": "vitest"
   },
   "dependencies": {


### PR DESCRIPTION
This causes the script to fail when dev dependencies are pruned, which occurs on heroku and similar servers